### PR TITLE
1.0.6

### DIFF
--- a/Monitoring/Monitoring.psd1
+++ b/Monitoring/Monitoring.psd1
@@ -3,7 +3,7 @@
 	RootModule = 'Monitoring.psm1'
 	
 	# Version number of this module.
-	ModuleVersion = '1.0.5'
+	ModuleVersion = '1.0.6'
 	
 	# ID used to uniquely identify this module
 	GUID = '690f8e43-7a62-420c-b68c-659713e944e2'

--- a/Monitoring/changelog.md
+++ b/Monitoring/changelog.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
 
+## 1.0.6 (2021-09-24)
+
++ Fix: Get-MonTarget - Now correctly returns untagged targets when no tag filter is specified
+
 ## 1.0.5 (2021-09-24)
 
 + Upd: Set-MonTarget - Added -RemoveTag and -RemoveCapability parameters

--- a/Monitoring/functions/target/Get-MonTarget.ps1
+++ b/Monitoring/functions/target/Get-MonTarget.ps1
@@ -57,7 +57,7 @@
 					break
 				}
 			}
-			if (-not $foundTag) { continue }
+			if (-not $foundTag -and ($Tag -notcontains '*')) { continue }
 			#endregion Filter by Tag
 			
 			$clonedItem['PSTypeName'] = 'Monitoring.Target'


### PR DESCRIPTION
+ Fix: Get-MonTarget - Now correctly returns untagged targets when no tag filter is specified